### PR TITLE
Add update_issuelib_entries script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ RAILS_ENV=production bundle exec rails runner find_xss.rb
 * `load_project_from_api` - Query a remote JSON API response to get project data and create matching Projects in the Dradis appliance.
 * `project_stats.rb` - Find which issues have been found across multiple projects and other project stats.
 * `daily_summary.rb` - Finds and outputs all of the Issues added to Dradis in the past 24 hours.
-
+* `update_issuelib_entries.rb` - Update your IssueLibrary entries with a quick script. This example adds new fields to all IssueLibrary entries and replaces a specific field if found. 
 
 # What does each script do?
 

--- a/update_issuelib_entries.rb
+++ b/update_issuelib_entries.rb
@@ -1,0 +1,32 @@
+# update_entries.rb - Updates all IssueLibrary entries to replace plugin_id with nessus_id (if found)
+#   and adds a new Status field to all entries. 
+#
+# Copyright (C) 2017 Security Roots Ltd.
+#
+# This file is part of the Dradis Pro Scripting Examples (DPSE) collection.
+# The collection can be found at
+#   https://github.com/securityroots/dradispro-scripting
+#
+# DPSE free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# DPSE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DPSE.  If not, see <http://www.gnu.org/licenses/>.
+
+Dradis::Pro::Issuelib::Entry.find do |libentry|
+  libentry.content << "\r\n\r\n#[Status]#\r\nOpen | Closed\r\n"
+  puts "Adding fields to IssueLibrary entry #{libentry.id}"
+  libentry.save
+  if libentry.content.include? "#[plugin_id]#"
+    libentry.content.sub!('#[plugin_id]#', '#[nessus_id]#')
+    libentry.save
+    puts "Replacing fields in IssueLibrary entry #{libentry.id}"
+  end
+end


### PR DESCRIPTION
This example script updates all IssueLibrary entries to replace the `plugin_id` field (if found) with a `nessus_id` field and also adds a new Status field to all entries. 