### PR TITLE
Script to reset duplicate issue tags to Dradis defaults

### DIFF
--- a/reset_default_tags.rb
+++ b/reset_default_tags.rb
@@ -1,0 +1,28 @@
+Project.includes(:tags).all.each do |project|
+    tags = project.tags
+  
+    tags.each do |tag|
+      match_data = tag.name.match(/!.{6}_(critical|high|medium|low|info)/)
+  
+  
+      if match_data
+        original_tag_name = match_data.captures[0]
+        default_tag = Tag::DEFAULT_TAGS.find { |x| x.split('_')[1] == original_tag_name }
+  
+        project.issues.includes(:taggings).where(taggings: { tag: tag }).each do |issue|
+          issue.tag_list = default_tag
+        end
+      end
+    end
+  end
+  
+  tags = Tag.all
+  tags.each do |tag|
+    match_data = tag.name.match(/!.{6}_(critical|high|medium|low|info)/)
+  
+    if match_data
+      if !Tag::DEFAULT_TAGS.include?(tag.name)
+        tag.destroy
+      end
+    end
+  end


### PR DESCRIPTION
### Summary

Script to help restore all tags to the dradis default tags in case multiple tags were created and user doesn't need them anymore.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
