### PR TITLE
Create clear_trash_6_months.rb

### DIFF
--- a/clear_trash_6_months.rb
+++ b/clear_trash_6_months.rb
@@ -1,0 +1,29 @@
+# clear_trash_6_months.rb - deletes items discarded in Trash
+#
+# Copyright (C) 2023 Security Roots Ltd.
+#
+# This file is part of the Dradis Pro Scripting Examples (DPSE) collection.
+# The collection can be found at
+#   https://github.com/securityroots/dradispro-scripting
+#
+# DPSE free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# DPSE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DPSE.  If not, see <http://www.gnu.org/licenses/>.
+
+days_ago = 6.months.ago
+
+Project.where()
+
+Project.where('projects.discarded_at <= ?', days_ago).each do |project|
+  project.destroy
+  puts "#{project.discarded_at} - Project '#{project.name}' fully deleted"
+end


### PR DESCRIPTION
### Summary

Adds a script that deleted discarded items in Trash older than 6 months.  Can be combined with a cron job to keep from storing older data.


### Other Information

🌮 to Rachael for making the script!


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
